### PR TITLE
fix: include install instructions in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,14 @@ jobs:
         with:
           files: sift-${{ github.ref_name }}.zip
           generate_release_notes: true
+          body: |
+            ## Install
+
+            1. Download **sift-${{ github.ref_name }}.zip** from the assets below
+            2. Unzip the file
+            3. Open `chrome://extensions` in Chrome
+            4. Enable **Developer Mode** (toggle in the top-right corner)
+            5. Click **Load unpacked** and select the `dist/` folder from the unzipped archive
+            6. Pin Sift from the extensions toolbar — you're ready to go
+
+            > **First time?** Open the Sift popup, pick your interests, then browse Hacker News, Reddit, or X to see scoring in action.


### PR DESCRIPTION
## Summary
- Adds install instructions to the `body` field of the GitHub Release workflow, so every release page is self-contained — no more jumping between the README and the release page
- Existing releases (v0.1.1, v0.1.2) have already been updated manually

### Before
![image](https://github.com/user-attachments/assets/before-release-no-instructions)
Just a changelog link — users had to find install steps in the README.

### After (v0.1.2, already live)
The release page now starts with step-by-step install instructions:

> ## Install
> 1. Download **sift-v0.1.2.zip** from the assets below
> 2. Unzip the file
> 3. Open `chrome://extensions` in Chrome
> 4. Enable **Developer Mode** (toggle in the top-right corner)
> 5. Click **Load unpacked** and select the `dist/` folder from the unzipped archive
> 6. Pin Sift from the extensions toolbar — you're ready to go

See it live: https://github.com/shreyaskarnik/Sift/releases/tag/v0.1.2

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)